### PR TITLE
Console Animation Improvements

### DIFF
--- a/lstc-web/css/index.scss
+++ b/lstc-web/css/index.scss
@@ -131,28 +131,29 @@ a {
 
   &__character {
     display: inline-block;
+    animation: reveal 0ms step-end 0ms 1 normal forwards;
   }
 
-  &__cursor {
-    display: inline-block;
+  &::before {
+    content: '> ';
+  }
+
+  &::after {
     background-color: $GREEN;
-    animation: blinker 1s linear infinite;
+    content: '\00a0';
+    animation: blinker 1s linear infinite normal forwards;
   }
 }
 
 @keyframes reveal {
   0% {
-    opacity: 0;
+    visibility: hidden;
     width: 0;
-  }
-
-  99% {
-    opacity: 0;
-    width: 0;
+    display: inline;
   }
 
   100% {
-    opacity: 1;
+    visibility: visible;
     width: auto;
     display: inline;
   }

--- a/lstc-web/css/index.scss
+++ b/lstc-web/css/index.scss
@@ -128,6 +128,7 @@ a {
 
 .console {
   color: $GREEN;
+  text-shadow: 0 0 5px $GREEN;
 
   &__character {
     display: inline-block;

--- a/lstc-web/src/components/atoms/console.rs
+++ b/lstc-web/src/components/atoms/console.rs
@@ -15,7 +15,7 @@ pub fn console(props: &ConsoleProps) -> Html {
     html!(
         <div class="console">
             {for s.chars().enumerate().map(|(ix, c)| html!(
-                <span class="console__character" style={format!("animation-duration: {}ms", ix*props.delay)}>{c}</span>
+                <span class="console__character" style={format!("animation-duration: {}ms", (ix+1)*props.delay)}>{c}</span>
             ))}
         </div>
     )

--- a/lstc-web/src/components/atoms/console.rs
+++ b/lstc-web/src/components/atoms/console.rs
@@ -5,7 +5,7 @@ use crate::components::Template;
 #[derive(Properties, PartialEq)]
 pub struct ConsoleProps {
     pub text: String,
-    #[prop_or(250)]
+    #[prop_or(100)]
     pub delay: usize,
 }
 
@@ -15,9 +15,8 @@ pub fn console(props: &ConsoleProps) -> Html {
     html!(
         <div class="console">
             {for s.chars().enumerate().map(|(ix, c)| html!(
-                <span class="console__character" style={format!("animation: reveal {}ms linear", ix*props.delay)}>{c}</span>
+                <span class="console__character" style={format!("animation-duration: {}ms", ix*props.delay)}>{c}</span>
             ))}
-            <span class="console__cursor" style={format!("animation-duration: {}ms", 1000)}>{"\u{00a0}"}</span>
         </div>
     )
 }


### PR DESCRIPTION
Improvements to the console animation to fix the issues outlined during the in-person event.

1. Use the `step-end` to make the characters snap into place, rather than linear slide in.
2. Remove the 99% keyframe now made redundant by the `step-end`
3. Replace the `animation-delay` with `animation-duration` so that all animations start at the same time, meaning their initial state is controlled by keyframes rather than the `.console__character` class.
4. Added `.console::before` and `.console::after` to reduce the number of HTML tags needed to produce the effect.
5. Changed the default delay to `100ms` 
6. Made the `.console::after` `content` use the `&nbsp;` equivalent of `\00a0` because it fills the vertical heigh better than `█`.
7. Uses `visibility` rather than `opacity` as `opacity` causes the character to appear incorrectly.
8. Added `text-shadow` to make the characters glow, as though they were a showing on an old CRT monitor.